### PR TITLE
Add utility to delete indexes for mongo version > 2.6.3

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mongo/EnsureIndexDelete.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/EnsureIndexDelete.scala
@@ -1,0 +1,19 @@
+package uk.gov.hmrc.mongo
+
+import reactivemongo.bson.{BSONInteger, BSONString, BSONDocument}
+import reactivemongo.core.commands.{CommandError, BSONCommandResultMaker, Command}
+
+
+case class EnsureIndexDelete(collection: String, index: String) extends Command[Int] {
+  override def makeDocuments = BSONDocument(
+    "deleteIndexes" -> BSONString(collection),
+    "index" -> BSONString(index))
+
+  object ResultMaker extends BSONCommandResultMaker[Int] {
+    def apply(document: BSONDocument) = CommandError
+      .checkOk(document, Some("deleteIndexes"))
+      .filterNot(_.getMessage().contains(s"index not found with name [$index]"))
+      .toLeft(document.getAs[BSONInteger]("nIndexesWas").map(_.value.toInt).get)
+  }
+}
+

--- a/src/test/scala/uk/gov/hmrc/mongo/EnsureIndexDeleteSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/EnsureIndexDeleteSpec.scala
@@ -1,0 +1,45 @@
+package uk.gov.hmrc.mongo
+
+
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.{WordSpecLike, Matchers, BeforeAndAfterEach, LoneElement}
+import play.api.libs.json.Format
+import reactivemongo.api.indexes.Index
+import reactivemongo.api.indexes.IndexType._
+import reactivemongo.bson.BSONObjectID
+
+class EnsureIndexDeleteSpec
+  extends WordSpecLike
+  with Matchers
+  with Awaiting
+  with MongoSpecSupport
+  with ScalaFutures
+  with IntegrationPatience
+  with BeforeAndAfterEach {
+
+  "Trying to delete an index" should {
+    "work if the index already exists" in {
+      repo.collection.indexesManager.create(Index(Seq("testField_1" -> Ascending), name = Some("indexToBeDeleted"))).futureValue
+      repo.collection.indexesManager.create(Index(Seq("testField_2" -> Ascending), name = Some("indexToBeKept"))).futureValue
+
+      repo.collection.db.command(EnsureIndexDelete(collectionName, "indexToBeDeleted")).futureValue
+
+      repo.collection.indexesManager.list().futureValue.map(_.name) should be(List(Some("_id_"), Some("indexToBeKept")))
+    }
+
+    "do nothing if the index does not exist" in {
+      repo.collection.indexesManager.create(Index(Seq("testField_2" -> Ascending), name = Some("indexToBeKept"))).futureValue
+
+      repo.collection.db.command(EnsureIndexDelete(collectionName, "indexThatDoesntExist")).futureValue
+
+      repo.collection.indexesManager.list().futureValue.map(_.name) should be(List(Some("_id_"), Some("indexToBeKept")))
+    }
+  }
+
+  override protected def beforeEach() {
+    await(repo.drop)
+  }
+
+  val collectionName = "EnsureIndexDeletedSpec"
+  lazy val repo = new ReactiveRepository[String, BSONObjectID](collectionName = collectionName, mongo, implicitly[Format[String]]) {}
+}


### PR DESCRIPTION
SA-578 
`EnsureDeleteIndex` works around a bug in reactive mongo. 
Also succeeds if target index does not exist (and therefore does not need to be deleted)

Move `EnsureDeleteIndex` to simple-reactivemongo as it is copied into 3 services at present.