### PR TITLE
Update index definition

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mongo/IndexUpdate.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/IndexUpdate.scala
@@ -74,13 +74,13 @@ trait IndexUpdate {
     }
   }
 
-  private def flagsNeedsUpdate(index: Index, existingIndex: Index): Boolean =
+  private def flagsNeedUpdate(index: Index, existingIndex: Index): Boolean =
     Seq(index.background ^ existingIndex.background,
         index.dropDups ^ existingIndex.dropDups,
         index.sparse ^ existingIndex.sparse,
         index.unique ^ existingIndex.unique) exists (_ == true)
 
   private def requiresUpdate(newIndex: Index, existingIndex: Index): Boolean = (newIndex.eventualName == existingIndex.eventualName &&
-    (newIndex.options != existingIndex.options || keyNeedsUpdate(newIndex, existingIndex) || flagsNeedsUpdate(newIndex, existingIndex)))
+    (newIndex.options != existingIndex.options || keyNeedsUpdate(newIndex, existingIndex) || flagsNeedUpdate(newIndex, existingIndex)))
 
 }

--- a/src/main/scala/uk/gov/hmrc/mongo/IndexUpdate.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/IndexUpdate.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mongo
+
+import ch.qos.logback.classic.Logger
+import reactivemongo.api.indexes.Index
+import reactivemongo.bson.{BSONDocument, BSONInteger, BSONString}
+import reactivemongo.core.commands.{BSONCommandResultMaker, Command, CommandError}
+import reactivemongo.json.collection.JSONCollection
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+
+trait IndexUpdate {
+  def collection: JSONCollection
+
+  protected def logger: Logger
+
+  object Update extends Enumeration {
+    type IndexUpdateType = Value
+    val NO_UPDATE, INSERT, MODIFY = Value
+  }
+
+  import Update._
+
+  private def needsUpdate(newIndex: Index, existingIndex: Option[Index]): IndexUpdateType = {
+    def keyNeedsUpdate(newIndex: Index, existingIndex: Index) = {
+      val newIndexKeys = newIndex.key.toMap
+      val existingIndexKeys = existingIndex.key.toMap
+      newIndexKeys.exists { case (name, _type) =>
+        val existing = existingIndexKeys.get(name)
+        !existing.isDefined || existing.get != _type
+      }
+    }
+
+    existingIndex map { idx: Index =>
+      if (newIndex.eventualName == idx.eventualName &&
+        (!newIndex.options.equals(idx.options) || keyNeedsUpdate(newIndex, idx))) MODIFY
+      else NO_UPDATE
+    } getOrElse (INSERT)
+  }
+
+  def updateIndexDefinition(indexes: Index*): Future[Seq[Boolean]] = {
+    collection.indexesManager.list() flatMap { existingIndexes =>
+      val existingIndexesAsMap = existingIndexes.map(idx => (idx.eventualName, idx)).toMap
+      Future.sequence {
+        indexes map { newIndex =>
+          val updateType = needsUpdate(newIndex, existingIndexesAsMap.get(newIndex.eventualName))
+          if (NO_UPDATE != updateType) update(newIndex, updateType)
+          else Future.successful(false)
+        }
+      }
+    }
+  }
+
+  private def update(newIndex: Index, updateType: IndexUpdateType): Future[Boolean] = {
+    val ensureIndex = () => collection.indexesManager.ensure(newIndex).recover {
+      case t =>
+        logger.error("ensuring index failed", t)
+        false
+    }
+    if (updateType == MODIFY) for {
+      deleted <- collection.db.command(DeleteIndex(collection.name, newIndex.eventualName))
+      updated <- ensureIndex()
+    } yield updated
+    else ensureIndex()
+  }
+
+}
+
+sealed case class DeleteIndex(
+                               collection: String,
+                               index: String) extends Command[Int] {
+  override def makeDocuments = BSONDocument(
+    "deleteIndexes" -> BSONString(collection),
+    "index" -> BSONString(index))
+
+  object ResultMaker extends BSONCommandResultMaker[Int] {
+    def apply(document: BSONDocument) =
+      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONInteger]("nIndexesWas").map(_.value).get)
+  }
+
+}

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -16,9 +16,6 @@
 
 package uk.gov.hmrc.mongo
 
-import org.slf4j.LoggerFactory
-import ch.qos.logback.classic.Logger
-import reactivemongo.api.indexes.{CollectionIndexesManager, IndexesManager, Index}
 import play.api.libs.json.{Format, Json}
 import reactivemongo.api.DB
 import reactivemongo.core.commands.{Count, LastError}
@@ -26,7 +23,6 @@ import reactivemongo.json.collection.JSONCollection
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
 
 
 abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
@@ -38,16 +34,16 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
   extends Repository[A, ID] with Indexes with IndexUpdate {
 
   import play.api.libs.json.Json.JsValueWrapper
-  import scala.concurrent.ExecutionContext.Implicits.global
   import reactivemongo.core.commands.GetLastError
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
   implicit val domainFormatImplicit = domainFormat
   implicit val idFormatImplicit = idFormat
 
-  override lazy val collection = mc.getOrElse(mongo().collection[JSONCollection](collectionName))
+  implicit lazy val collection = mc.getOrElse(mongo().collection[JSONCollection](collectionName))
 
-  override protected val logger = LoggerFactory.getLogger(this.getClass).asInstanceOf[Logger]
-  val message: String = "ensuring index failed"
+  def updateExistingIndexes: Boolean
 
   ensureIndexes
 
@@ -79,17 +75,8 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
 
   override def insert(entity: A)(implicit ec: ExecutionContext) = collection.insert(entity)
 
-  private def ensureIndex(index: Index)(implicit ec: ExecutionContext): Future[Boolean] = {
-    collection.indexesManager.ensure(index).recover {
-      case t =>
-        logger.error(message, t)
-        false
-    }
-  }
-
-  def ensureIndexes(implicit ec: ExecutionContext): Future[Seq[Boolean]] = {
-//    Future.sequence(indexes.map(ensureIndex))
-    updateIndexDefinition(indexes :_*)
-  }
+  def ensureIndexes(implicit ec: ExecutionContext): Future[Seq[Boolean]] =
+    if (updateExistingIndexes) updateIndexDefinition(indexes :_*)
+    else Future.sequence(indexes.map(ensureIndex))
 
 }

--- a/src/test/scala/uk/gov/hmrc/mongo/AtomicUpdateSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/AtomicUpdateSpec.scala
@@ -151,6 +151,7 @@ class AtomicUpdateSpec extends WordSpec with Matchers with MongoSpecSupport with
   class AtomicTestRepository(implicit mc: MongoConnector)
     extends ReactiveRepository[AtomicTestObject, BSONObjectID]("simpleTestRepository", mc.db, AtomicTestObject.formats, ReactiveMongoFormats.objectIdFormats)
     with AtomicUpdate[AtomicTestObject] {
+    override val updateExistingIndexes: Boolean = false
 
     override def indexes = Seq(
       Index(Seq("name" -> IndexType.Ascending), name = Some("aNameUniqueIdx"), unique = true, sparse = true)
@@ -158,6 +159,7 @@ class AtomicUpdateSpec extends WordSpec with Matchers with MongoSpecSupport with
 
     override def isInsertion(suppliedId: BSONObjectID, returned: AtomicTestObject): Boolean =
       suppliedId.equals(returned.id)
+
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/mongo/EnsureIndexDeleteSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/EnsureIndexDeleteSpec.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.mongo
 
 
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{WordSpecLike, Matchers, BeforeAndAfterEach, LoneElement}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
 import play.api.libs.json.Format
 import reactivemongo.api.indexes.Index
 import reactivemongo.api.indexes.IndexType._
@@ -57,5 +57,7 @@ class EnsureIndexDeleteSpec
   }
 
   val collectionName = "EnsureIndexDeletedSpec"
-  lazy val repo = new ReactiveRepository[String, BSONObjectID](collectionName = collectionName, mongo, implicitly[Format[String]]) {}
+  lazy val repo = new ReactiveRepository[String, BSONObjectID](collectionName = collectionName, mongo, implicitly[Format[String]]) {
+    override val updateExistingIndexes: Boolean = false
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/mongo/IndexUpdateSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/IndexUpdateSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.mongo
 
-import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.{Level, Logger}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{LoneElement, Matchers, WordSpec}
@@ -26,18 +26,17 @@ import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.BSONDocument
 import reactivemongo.json.collection.JSONCollection
 
-class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with Awaiting with ScalaFutures with LoneElement {
+class IndexUpdateSpec extends WordSpec with Matchers with MongoSpecSupport with Awaiting with ScalaFutures with LoneElement with LogCapturing {
 
 
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Millis)), interval = scaled(Span(150, Millis)))
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(500, Millis)), interval = scaled(Span(100, Millis)))
 
   private trait Setup {
     await(mongo().drop())
-    val testCollection = mongo().collection[JSONCollection]("testCollection")
-
+    implicit val testCollection = mongo().collection[JSONCollection]("testCollection")
+    val loggerForTest = LoggerFactory.getLogger(this.getClass).asInstanceOf[Logger]
     val indexUpdate = new IndexUpdate {
-      override protected val logger = LoggerFactory.getLogger(this.getClass).asInstanceOf[Logger]
-      override def collection: JSONCollection = testCollection
+      override protected def logger: Logger = loggerForTest
     }
   }
 
@@ -50,7 +49,28 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), unique = true)
       indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
 
-      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
+    }
+
+    "add a new field to the key of existing index" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Ascending, "otherRepoField" -> IndexType.Descending), unique = true)
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
+    }
+
+
+    "remove a field from the key of existing index" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending, "otherRepoField" -> IndexType.Descending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), unique = true)
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
     }
 
     "do nothing and return false if index is up to date" in new Setup {
@@ -60,7 +80,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
 
       indexUpdate.updateIndexDefinition(index).futureValue.loneElement shouldBe false
 
-      testCollection.indexesManager.list().futureValue  should contain(index)
+      testCollection.indexesManager.list().futureValue should contain(index)
     }
 
     "insert a new index and return true if index does not exist already" in new Setup {
@@ -68,7 +88,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
 
       indexUpdate.updateIndexDefinition(index).futureValue.loneElement shouldBe true
 
-      testCollection.indexesManager.list().futureValue  should contain(index)
+      testCollection.indexesManager.list().futureValue should contain(index)
     }
 
     "update one index out of two and return proper Seq[Boolean] when the index not being updated exists and is up to date" in new Setup {
@@ -80,7 +100,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index1.copy(Seq("repoField1" -> IndexType.Descending))
       indexUpdate.updateIndexDefinition(updatedIndex, index2).futureValue shouldBe Seq(true, false)
 
-      testCollection.indexesManager.list().futureValue  should (contain(index2) and contain(updatedIndex))
+      testCollection.indexesManager.list().futureValue should (contain(index2) and contain(updatedIndex) and not contain(index1))
     }
 
     "update one index, insert the other and return proper Seq[Boolean] when the index being inserted does not exist already" in new Setup {
@@ -92,7 +112,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index1.copy(Seq("repoField1" -> IndexType.Descending))
       indexUpdate.updateIndexDefinition(updatedIndex, index2).futureValue shouldBe Seq(true, true)
 
-      testCollection.indexesManager.list().futureValue  should (contain(index2) and contain(updatedIndex))
+      testCollection.indexesManager.list().futureValue should (contain(index2) and contain(updatedIndex) and not contain(index1))
     }
 
   }
@@ -106,7 +126,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), options = BSONDocument("expireAfterSeconds" -> 123456L))
       indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
 
-      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
     }
 
     "change the options of index and return true if the given option is set to a different value in the new index" in new Setup {
@@ -116,7 +136,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), options = BSONDocument("expireAfterSeconds" -> 123469L))
       indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
 
-      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
     }
 
     "change the options of index and return true if the given option is not set in the new index" in new Setup {
@@ -126,7 +146,7 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), options = BSONDocument("expireAfterSeconds" -> 123456L))
       indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
 
-      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
     }
 
 
@@ -137,13 +157,12 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
       val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending))
       indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
 
-      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(index))
     }
 
     "do nothing and return false if index is up to date" in new Setup {
       val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1), options = BSONDocument("expireAfterSeconds" -> 123456L))
       await(testCollection.indexesManager.create(index))
-
 
       indexUpdate.updateIndexDefinition(index).futureValue.loneElement shouldBe false
 
@@ -151,18 +170,35 @@ class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with
     }
   }
 
-  "updating index when records that don\'t comply with the index exist" should {
-    "do not update index and log error" in new Setup {
+  "updating the flags of an index" should {
+
+    "change the flags accordingly and return true" in new Setup {
       val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
       await(testCollection.indexesManager.create(index))
+      val updatedIndex = index.copy(unique = true, sparse = true)
 
-      testCollection.save(Json.obj("repoField" -> "duplicate" )).futureValue should have('inError(false))
-//      testCollection.save(Json.obj("repoField" -> "duplicate" )).futureValue should have('inError(false))
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
 
-      val updatedIndex = index.copy(unique = true)
-
-      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe false
-      testCollection.indexesManager.list().futureValue should contain(index)
+      testCollection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain (index))
     }
+
+    "do not update index and log error if the unique flag needs to be set to true but there are dups in the db" in new Setup {
+        val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+        await(testCollection.indexesManager.create(index))
+
+        testCollection.save(Json.obj("repoField" -> "duplicate")).futureValue should have('inError(false))
+        testCollection.save(Json.obj("repoField" -> "duplicate")).futureValue should have('inError(false))
+
+        val updatedIndex = index.copy(unique = true)
+
+      withCaptureOfLoggingFrom(loggerForTest) { logEvents =>
+        indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe false
+        testCollection.indexesManager.list().futureValue should (contain(index) and not contain (updatedIndex))
+
+        logEvents.filter(_.getLevel == Level.ERROR).loneElement.getMessage should include (s"Definition of index ${updatedIndex.eventualName} cannot be updated")
+      }
+    }
+
   }
+
 }

--- a/src/test/scala/uk/gov/hmrc/mongo/IndexUpdateSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/IndexUpdateSpec.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mongo
+
+import ch.qos.logback.classic.Logger
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Span}
+import org.scalatest.{LoneElement, Matchers, WordSpec}
+import org.slf4j.LoggerFactory
+import play.api.libs.json.Json
+import reactivemongo.api.indexes.{Index, IndexType}
+import reactivemongo.bson.BSONDocument
+import reactivemongo.json.collection.JSONCollection
+
+class IndexUpdateSpec extends WordSpec with Matchers  with MongoSpecSupport with Awaiting with ScalaFutures with LoneElement {
+
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Millis)), interval = scaled(Span(150, Millis)))
+
+  private trait Setup {
+    await(mongo().drop())
+    val testCollection = mongo().collection[JSONCollection]("testCollection")
+
+    val indexUpdate = new IndexUpdate {
+      override protected val logger = LoggerFactory.getLogger(this.getClass).asInstanceOf[Logger]
+      override def collection: JSONCollection = testCollection
+    }
+  }
+
+  "updating the type of index" should {
+
+    "change the type of index and return true" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), unique = true)
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+    }
+
+    "do nothing and return false if index is up to date" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index))
+
+
+      indexUpdate.updateIndexDefinition(index).futureValue.loneElement shouldBe false
+
+      testCollection.indexesManager.list().futureValue  should contain(index)
+    }
+
+    "insert a new index and return true if index does not exist already" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+
+      indexUpdate.updateIndexDefinition(index).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue  should contain(index)
+    }
+
+    "update one index out of two and return proper Seq[Boolean] when the index not being updated exists and is up to date" in new Setup {
+      val index1 = Index(Seq("repoField1" -> IndexType.Ascending), name = Some("indexName1"), unique = false, sparse = false, version = Some(1))
+      val index2 = Index(Seq("repoField2" -> IndexType.Ascending), name = Some("indexName2"), unique = true, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index1))
+      await(testCollection.indexesManager.create(index2))
+
+      val updatedIndex = index1.copy(Seq("repoField1" -> IndexType.Descending))
+      indexUpdate.updateIndexDefinition(updatedIndex, index2).futureValue shouldBe Seq(true, false)
+
+      testCollection.indexesManager.list().futureValue  should (contain(index2) and contain(updatedIndex))
+    }
+
+    "update one index, insert the other and return proper Seq[Boolean] when the index being inserted does not exist already" in new Setup {
+      val index1 = Index(Seq("repoField1" -> IndexType.Ascending), name = Some("indexName1"), unique = false, sparse = false, version = Some(1))
+      val index2 = Index(Seq("repoField2" -> IndexType.Ascending), name = Some("indexName2"), unique = true, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index1))
+
+
+      val updatedIndex = index1.copy(Seq("repoField1" -> IndexType.Descending))
+      indexUpdate.updateIndexDefinition(updatedIndex, index2).futureValue shouldBe Seq(true, true)
+
+      testCollection.indexesManager.list().futureValue  should (contain(index2) and contain(updatedIndex))
+    }
+
+  }
+
+  "updating the options of index" should {
+
+    "change the options of index and return true if the given option is not set" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), options = BSONDocument("expireAfterSeconds" -> 123456L))
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+    }
+
+    "change the options of index and return true if the given option is set to a different value in the new index" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1), options = BSONDocument("expireAfterSeconds" -> 123456L))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), options = BSONDocument("expireAfterSeconds" -> 123469L))
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+    }
+
+    "change the options of index and return true if the given option is not set in the new index" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1), options = BSONDocument("expireAfterSeconds" -> 123456L, "otherOption" -> "someValue"))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending), options = BSONDocument("expireAfterSeconds" -> 123456L))
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+    }
+
+
+    "remove the options of index and return true if the new index has no options" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1), options = BSONDocument("expireAfterSeconds" -> 123456L, "otherOption" -> "someValue"))
+      await(testCollection.indexesManager.create(index))
+
+      val updatedIndex = index.copy(Seq("repoField" -> IndexType.Descending))
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe true
+
+      testCollection.indexesManager.list().futureValue should contain(updatedIndex)
+    }
+
+    "do nothing and return false if index is up to date" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1), options = BSONDocument("expireAfterSeconds" -> 123456L))
+      await(testCollection.indexesManager.create(index))
+
+
+      indexUpdate.updateIndexDefinition(index).futureValue.loneElement shouldBe false
+
+      testCollection.indexesManager.list().futureValue should contain(index)
+    }
+  }
+
+  "updating index when records that don\'t comply with the index exist" should {
+    "do not update index and log error" in new Setup {
+      val index = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = false, sparse = false, version = Some(1))
+      await(testCollection.indexesManager.create(index))
+
+      testCollection.save(Json.obj("repoField" -> "duplicate" )).futureValue should have('inError(false))
+//      testCollection.save(Json.obj("repoField" -> "duplicate" )).futureValue should have('inError(false))
+
+      val updatedIndex = index.copy(unique = true)
+
+      indexUpdate.updateIndexDefinition(updatedIndex).futureValue.loneElement shouldBe false
+      testCollection.indexesManager.list().futureValue should contain(index)
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/mongo/LogCapturing.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/LogCapturing.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mongo
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.slf4j.LoggerFactory
+import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
+import scala.collection.JavaConverters._
+
+
+/**
+ * Created by cls on 28/03/15.
+ */
+trait LogCapturing {
+
+  import scala.reflect._
+
+  def withCaptureOfLoggingFrom[T: ClassTag](body: (=> List[ILoggingEvent]) => Any): Any = {
+    val logger = LoggerFactory.getLogger(classTag[T].runtimeClass).asInstanceOf[LogbackLogger]
+    withCaptureOfLoggingFrom(logger)(body)
+  }
+
+  def withCaptureOfLoggingFrom(logger: LogbackLogger)(body: (=> List[ILoggingEvent]) => Any): Any = {
+    val appender = new ListAppender[ILoggingEvent]()
+    appender.setContext(logger.getLoggerContext)
+    appender.start()
+    logger.addAppender(appender)
+    logger.setLevel(Level.ALL)
+    logger.setAdditive(true)
+    body(appender.list.asScala.toList)
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
@@ -16,22 +16,17 @@
 
 package uk.gov.hmrc.mongo
 
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
-import ch.qos.logback.core.read.ListAppender
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
-import org.scalatest.concurrent.{ScalaFutures, Eventually}
-import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{LoneElement, BeforeAndAfterEach, Matchers, WordSpec}
-import org.slf4j.LoggerFactory
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterEach, LoneElement, Matchers, WordSpec}
 import play.api.libs.json.{JsValue, Json}
 import reactivemongo.api.indexes.{Index, IndexType}
-import reactivemongo.bson.{BSONInteger, BSONString, BSONDocument, BSONObjectID}
-import reactivemongo.core.commands.{CommandError, BSONCommandResultMaker, Command}
+import reactivemongo.bson.{BSONDocument, BSONObjectID}
 import reactivemongo.core.errors.DatabaseException
 import uk.gov.hmrc.mongo.json.{ReactiveMongoFormats, TupleFormats}
 
-import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.{ExecutionContext, Future}
 
 case class NestedModel(a: String, b: String)
 
@@ -67,6 +62,7 @@ object TestObject {
 
 class SimpleTestRepository(implicit mc: MongoConnector)
   extends ReactiveRepository[TestObject, BSONObjectID]("simpleTestRepository", mc.db, TestObject.formats, ReactiveMongoFormats.objectIdFormats) {
+  override val updateExistingIndexes: Boolean = false
 
   override def indexes = Seq(
     Index(Seq("aField" -> IndexType.Ascending), name = Some("aFieldUniqueIdx"), unique = true, sparse = true),
@@ -80,6 +76,8 @@ class FailingIndexesTestRepository(implicit mc: MongoConnector)
   override def indexes = Seq(
     Index(Seq("aField" -> IndexType.Ascending), name = Some("index1"), unique = true, sparse = true)
   )
+
+  override val updateExistingIndexes: Boolean = false
 }
 
 class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSupport with BeforeAndAfterEach with Awaiting with CurrentTime with Eventually with LogCapturing with LoneElement with ScalaFutures {
@@ -87,8 +85,10 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
   val repository =  new SimpleTestRepository
   val uniqueIndexRepository = new FailingIndexesTestRepository
 
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(500, Millis)), interval = scaled(Span(100, Millis)))
+
   override def beforeEach() {
-    await(repository.drop)
+    await(mongo().drop())
   }
 
   "findAll" should {
@@ -190,6 +190,7 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
   }
 
   "Creation of Indexes" should {
+
     "should be done based on provided Indexes" in new LogCapturing {
       await(repository.drop)
       await(repository.collection.indexesManager.list()) shouldBe empty
@@ -236,33 +237,29 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
         await(uniqueIndexRepository.ensureIndexes) shouldBe Seq(false)
         logList.size should be(1)
-        logList.head.getMessage shouldBe (uniqueIndexRepository.message)
+        logList.head.getMessage shouldBe (uniqueIndexRepository.ensureIndexFailedMessage)
 
       }
     }
 
     "update an index definition if index already exists" in {
-      await(mongo().drop())
       val oldIndex = Index(Seq("repoField" -> IndexType.Ascending), name = Some("indexName"), unique = true, sparse = true, version = Some(1))
       val updatedIndex = Index(Seq("repoField" -> IndexType.Descending), name = Some("indexName"), unique = false, sparse = false, version = Some(1), options = BSONDocument("expireAfterSeconds" -> 123456L))
+
       class SimpleTestRepository(implicit mc: MongoConnector)
         extends ReactiveRepository[TestObject, BSONObjectID]("repo", mc.db, TestObject.formats, ReactiveMongoFormats.objectIdFormats) {
-
-        override def indexes = Seq(
-          oldIndex
-        )
-
+        override lazy val updateExistingIndexes: Boolean = true
+        override def indexes = Seq(oldIndex)
         override def ensureIndexes(implicit ec: ExecutionContext): Future[Seq[Boolean]] = Future.successful(await(super.ensureIndexes))
       }
 
       class OtherRepo extends SimpleTestRepository {
-        override def indexes: Seq[Index] = Seq(
-          updatedIndex
-        )
+        override def indexes: Seq[Index] = Seq(updatedIndex)
       }
 
       val repo1 = new SimpleTestRepository
       val repo2 = new OtherRepo
+
       repo1.collection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(oldIndex))
       repo2.collection.indexesManager.list().futureValue should (contain(updatedIndex) and not contain(oldIndex))
     }
@@ -314,23 +311,3 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
   }
 }
 
-trait LogCapturing {
-
-  import scala.collection.JavaConverters._
-  import scala.reflect._
-
-  def withCaptureOfLoggingFrom[T: ClassTag](body: (=> List[ILoggingEvent]) => Any): Any = {
-    val logger = LoggerFactory.getLogger(classTag[T].runtimeClass).asInstanceOf[LogbackLogger]
-    withCaptureOfLoggingFrom(logger)(body)
-  }
-
-  def withCaptureOfLoggingFrom(logger: LogbackLogger)(body: (=> List[ILoggingEvent]) => Any): Any = {
-    val appender = new ListAppender[ILoggingEvent]()
-    appender.setContext(logger.getLoggerContext)
-    appender.start()
-    logger.addAppender(appender)
-    logger.setLevel(Level.ALL)
-    logger.setAdditive(true)
-    body(appender.list.asScala.toList)
-  }
-}

--- a/src/test/scala/uk/gov/hmrc/mongo/geospatial/GeospatialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/geospatial/GeospatialSpec.scala
@@ -39,7 +39,7 @@ object Place{
 class GeospatialTestRepository(implicit mc: MongoConnector)
   extends ReactiveRepository[Place, BSONObjectID]("geospatialTestRepository", mc.db, Place.formats, ReactiveMongoFormats.objectIdFormats)
   with Geospatial[Place, BSONObjectID]{
-
+  override val updateExistingIndexes: Boolean = false
   override def indexes = Seq(geo2DSphericalIndex)
 
 }


### PR DESCRIPTION
This feature enables the update of existing indexes in the DB. A ReactiveRepository specifies whether its indexes should have their definitions updated. If so, the following will happen:

- if the index does not exist then insert it
- if the index exists but the definition has not changed then do nothing
- if the index exists and the definition has changed then remove the old index and insert the new version of the index. If the insertion fails the old index is reinstated.

Every repository must override the boolean value 'updateExistingIndexes' in ReactiveRepository' to enable this behaviour (true) or keep the current (false). The value could be also defaulted.