### PR TITLE
Reactive repository paging

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -41,6 +41,15 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
     collection.find(Json.obj(query: _*)).cursor[A].collect[List]()
   }
 
+  def findPaged(pageSize: Int, page: Int, query: (String, JsValueWrapper)*)(implicit ec: ExecutionContext): Future[List[A]] = {
+    val amountToSkip = (page - 1) * pageSize
+    collection.find(Json.obj(query: _*))
+      .sort(JsObject(Seq(("_id", JsNumber(1)))))
+      .options(QueryOpts(amountToSkip, pageSize))
+      .cursor[A]
+      .collect[List](pageSize)
+  }
+
   def findAllPaged(pageSize: Int, page: Int)(implicit ec: ExecutionContext): Future[List[A]] ={
     val amountToSkip = (page - 1) * pageSize
     collection.find(Json.obj())

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -3,10 +3,12 @@ package uk.gov.hmrc.mongo
 import org.slf4j.LoggerFactory
 import ch.qos.logback.classic.Logger
 import reactivemongo.api.indexes.Index
-import play.api.libs.json.{Format, Json}
-import reactivemongo.api.DB
+import play.api.libs.json.{JsNumber, JsObject, Format, Json}
+import reactivemongo.api.{DB, QueryOpts}
+import reactivemongo.api.SortOrder
 import reactivemongo.core.commands.{Count, LastError}
 import reactivemongo.json.collection.JSONCollection
+import reactivemongo.bson.BSONDocument
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,6 +41,14 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
     collection.find(Json.obj(query: _*)).cursor[A].collect[List]()
   }
 
+  def findAllPaged(pageSize: Int, page: Int)(implicit ec: ExecutionContext): Future[List[A]] ={
+    val amountToSkip = (page - 1) * pageSize
+    collection.find(Json.obj())
+              .sort(JsObject(Seq(("_id", JsNumber(1)))))
+              .options(QueryOpts(amountToSkip, pageSize))
+              .cursor[A]
+              .collect[List](pageSize)
+}
   override def findAll(implicit ec: ExecutionContext): Future[List[A]] = collection.find(Json.obj()).cursor[A].collect[List]()
 
   override def findById(id: ID)(implicit ec: ExecutionContext): Future[Option[A]] = {

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -44,10 +44,10 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
   def findPaged(pageSize: Int, page: Int, query: (String, JsValueWrapper)*)(implicit ec: ExecutionContext): Future[List[A]] = {
     val amountToSkip = (page - 1) * pageSize
     collection.find(Json.obj(query: _*))
-      .sort(JsObject(Seq(("_id", JsNumber(1)))))
-      .options(QueryOpts(amountToSkip, pageSize))
-      .cursor[A]
-      .collect[List](pageSize)
+              .sort(JsObject(Seq(("_id", JsNumber(1)))))
+              .options(QueryOpts(amountToSkip, pageSize))
+              .cursor[A]
+              .collect[List](pageSize)
   }
 
   def findAllPaged(pageSize: Int, page: Int)(implicit ec: ExecutionContext): Future[List[A]] ={

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositoryPagingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositoryPagingSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{ BeforeAndAfterAll, Matchers, FeatureSpec }
 import org.scalatest.concurrent.Eventually
 import reactivemongo.core.commands.LastError
 import reactivemongo.bson.BSONObjectID
-import play.api.libs.json.{JsArray, JsString, JsObject, Json}
+import play.api.libs.json.{ JsArray, JsString, JsObject, Json }
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 class ReactiveRepositoryPagingSpec extends FeatureSpec with Matchers with MongoSpecSupport
@@ -21,46 +21,47 @@ class ReactiveRepositoryPagingSpec extends FeatureSpec with Matchers with MongoS
     clearTestDataFromMongo()
   }
 
-  feature("findAll paging") {
+  feature("findAll with paging") {
 
-    scenario("page 1, page size 1") {
+    scenario("returns the 1st result using ID ordering for page size 1 page 1") {
       val results = await(repository.findAllPaged(1, 1))
       results.map(_.aField) should be(Seq("1"))
     }
 
-    scenario("page 1, page size 5") {
+    scenario("returns the first 5 results using ID ordering for a page size 5 page 1") {
       val results = await(repository.findAllPaged(5, 1))
       results.map(_.aField) should be(Seq("1", "2", "3", "4", "5"))
     }
 
-    scenario("page 2, page size 1") {
+    scenario("returns the 2nd result using ID ordering for page size 1 page 2") {
       val results = await(repository.findAllPaged(1, 2))
       results.map(_.aField) should be(Seq("2"))
     }
 
-    scenario("page 5, page size 20") {
+    scenario("returns results 81 - 100 using ID ordering for page size 20 page 5") {
       val results = await(repository.findAllPaged(20, 5))
       results.map(_.aField) should be(Seq(
         "81", "82", "83", "84", "85", "86", "87", "88", "89",
         "90", "91", "92", "93", "94", "95", "96", "97", "98",
-        "99", "100"))
+        "99", "100")
+      )
     }
 
     scenario("zero page size returns empty search results") {
       await(repository.findAllPaged(0, 10)) should be(Seq.empty)
     }
 
-    scenario("page beyond valid results returns empty search results") {
+    scenario("page beyond end of results returns empty search results") {
       await(repository.findAllPaged(30, 5)) should be(Seq.empty)
     }
 
-    scenario("Non positive page number failure") {
+    scenario("Non positive page number causes error") {
       intercept[reactivemongo.core.errors.DetailedDatabaseException] {
         await(repository.findAllPaged(20, 0))
       }
     }
 
-    scenario("Non positive pageSize failure") {
+    scenario("Non positive pageSize causes error") {
       intercept[reactivemongo.core.errors.DetailedDatabaseException] {
         await(repository.findAllPaged(-1, 10))
       }
@@ -68,43 +69,43 @@ class ReactiveRepositoryPagingSpec extends FeatureSpec with Matchers with MongoS
 
   }
 
-  feature("find paging") {
+  feature("find with paging") {
 
-    scenario("pageSize 1, page 1 for 'or' query") {
-    	val query = or("aField", Seq(
-    		"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
-    	))  
+    scenario("returns first item matching query using ID ordering for page size 1 page 1") {
+      val query = or("aField", Seq(
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+      )
       val aFields = await(repository.findPaged(1, 1, query)).map(_.aField)
-      aFields should be(Seq("1")) 
+      aFields should be(Seq("1"))
     }
 
-    scenario("pageSize 2, page 3 for 'or' query returns 5 and 6") {
-    	val query = or("aField", Seq(
-    		"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
-    	))  
+    scenario("returns items 5 and 6 matching querying using ID ordering for page size 2 page 3") {
+      val query = or("aField", Seq(
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+      )
       val aFields = await(repository.findPaged(2, 3, query)).map(_.aField)
-      aFields should be(Seq("5","6")) 
+      aFields should be(Seq("5", "6"))
     }
 
     scenario("zero page size returns empty search results") {
-    	val query = or("aField", Seq("1"))
+      val query = or("aField", Seq("1"))
       await(repository.findPaged(0, 2, query)) should be(Seq.empty)
     }
 
-    scenario("page beyond valid results returns empty search results") {
-    	val query = or("aField", Seq("1"))
+    scenario("page beyond end of search results returns empty search results") {
+      val query = or("aField", Seq("1"))
       await(repository.findPaged(2, 2, query)) should be(Seq.empty)
     }
 
-    scenario("Non positive page number failure") {
-    	val query = or("aField", Seq("1"))
+    scenario("Non positive page number causes error") {
+      val query = or("aField", Seq("1"))
       intercept[reactivemongo.core.errors.DetailedDatabaseException] {
         await(repository.findPaged(5, -1, query))
       }
     }
 
-    scenario("Non positive pageSize failure") {
-    	val query = or("aField", Seq("1"))
+    scenario("Non positive page size causes error") {
+      val query = or("aField", Seq("1"))
       intercept[reactivemongo.core.errors.DetailedDatabaseException] {
         await(repository.findPaged(-1, 10, query))
       }
@@ -130,10 +131,10 @@ class ReactiveRepositoryPagingSpec extends FeatureSpec with Matchers with MongoS
     }
 
     def or(fieldName: String, values: Seq[String]) = {
-    	val fieldValues = values.map { v =>
-    		JsObject(Seq((fieldName, JsString(v))))
-    	}
-    	("$or", Json.toJsFieldJsValueWrapper(JsArray(fieldValues)))
+      val fieldValues = values.map { v =>
+        JsObject(Seq((fieldName, JsString(v))))
+      }
+      ("$or", Json.toJsFieldJsValueWrapper(JsArray(fieldValues)))
     }
 
     def clearTestDataFromMongo() {

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositoryPagingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositoryPagingSpec.scala
@@ -1,0 +1,102 @@
+package uk.gov.hmrc.mongo
+
+import scala.concurrent.Future
+import org.scalatest.{ BeforeAndAfterAll, Matchers, FeatureSpec }
+import org.scalatest.concurrent.Eventually
+import reactivemongo.core.commands.LastError
+import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+class ReactiveRepositoryPagingSpec extends FeatureSpec with Matchers with MongoSpecSupport
+  with Awaiting with Eventually with LogCapturing with BeforeAndAfterAll {
+
+  import TestData._
+
+  override def beforeAll() {
+    populateMongoWithTestData()
+  }
+
+  override def afterAll() {
+    clearTestDataFromMongo()
+  }
+
+  feature("findAll paging") {
+
+    scenario("page 1, page size 1") {
+      val results = await(repository.findAllPaged(1, 1))
+      results.map(_.aField) should be(Seq("1"))
+    }
+
+    scenario("page 1, page size 5") {
+      val results = await(repository.findAllPaged(5, 1))
+      results.map(_.aField) should be(Seq("1", "2", "3", "4", "5"))
+    }
+
+    scenario("page 2, page size 1") {
+      val results = await(repository.findAllPaged(1, 2))
+      results.map(_.aField) should be(Seq("2"))
+    }
+
+    scenario("page 5, page size 20") {
+      val results = await(repository.findAllPaged(20, 5))
+      results.map(_.aField) should be(Seq(
+        "81", "82", "83", "84", "85", "86", "87", "88", "89",
+        "90", "91", "92", "93", "94", "95", "96", "97", "98",
+        "99", "100"))
+    }
+
+    scenario("zero page size returns empty search results") {
+      await(repository.findAllPaged(0, 10)) should be(Seq.empty)
+    }
+
+    scenario("page beyond valid results returns empty search results") {
+      await(repository.findAllPaged(30, 5)) should be(Seq.empty)
+    }
+
+    scenario("Non positive page number failure") {
+      intercept[reactivemongo.core.errors.DetailedDatabaseException] {
+        await(repository.findAllPaged(20, 0))
+      }
+    }
+
+    scenario("Non positive pageSize failure") {
+      intercept[reactivemongo.core.errors.DetailedDatabaseException] {
+        await(repository.findAllPaged(-1, 10))
+      }
+    }
+
+  }
+
+  feature("find paging") {
+
+    scenario("TODO") {
+      // TODO 
+    }
+  }
+
+  object TestData {
+    val repository = new PagingTestsRepository
+
+    def populateMongoWithTestData() {
+      for (n <- (1 to 100)) {
+        val oId = padTo24Chars(n)
+        val o = TestObject(n.toString, id = BSONObjectID(oId))
+        await(repository.save(o))
+      }
+    }
+
+    private def padTo24Chars(n: Int): String = {
+      val s = n.toString
+      val zeros = 24 - s.length
+      val zs = (1 to zeros).fold("")((st, n) => s"${st}0")
+      s"${zs}$s"
+    }
+
+    def clearTestDataFromMongo() {
+      await(repository.removeAll)
+    }
+
+    class PagingTestsRepository(implicit mc: MongoConnector) extends ReactiveRepository[TestObject, BSONObjectID](
+      "pagingTestsRepository", mc.db, TestObject.formats, ReactiveMongoFormats.objectIdFormats) {}
+  }
+}


### PR DESCRIPTION
My name is Nick and I paired on this with Ross McCorkindale. We are working with the VOA and were advised to use this library which we found useful. However, it didn't provide the ability to page which we needed.

Please let us know if you want us to make any changes. We've listed some of the design trade-offs we considered below.

Design Trade-offs
~~~~~~~~~~~~~~
1. We added findAllPaged and findPaged to ReactiveRepository. Ideally we would have updated the Repository interface and made the the page and pageSize parameters optional. We decided to present you with this less-invasive approach first to get your feedback.

2. We used FeatureSpec rather than WordSpec for the tests because we wanted to test a variety of combinations and we felt FeatureSpec would allow us to express this more cleanly. We probably could bash WordSpec into shape if you prefer consistency.

3. We put the tests in a new file because the existing test file was already 250 lines long. We didn't want the test files to become huge and impact their ability to express behaviours.

4. In our test file we re-used a lot of the test helpers from the existing test file. However, we did add some of our own test data and helper methods which we put at the bottom of the test file so that would could accentuate the behaviours of the class we were testing; when someone comes to look at the file, the first thing they see is the behaviours and then they can drill down into the mechanics of the tests.
