### PR TITLE
Depreacting ReactiveRepository#save()

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -67,7 +67,8 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
     case _ => false
   }
 
-  override def save(entity: A)(implicit ec: ExecutionContext) = collection.save(entity)
+  @deprecated("use ReactiveRepository#insert() instead", "3.0.1")
+  override def save(entity: A)(implicit ec: ExecutionContext) = insert(entity)
 
   override def insert(entity: A)(implicit ec: ExecutionContext) = {
     domainFormat.writes(entity) match {

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
@@ -172,6 +172,20 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
     }
   }
 
+  "Saving an object" should {
+    "not upsert" in {
+
+      await(repository.drop)
+      await(repository.ensureIndexes)
+
+      val originalSave = TestObject("orignal-save")
+      await(repository.save(originalSave))
+
+      val notUpsert = originalSave.copy("should-not-upsert")
+      a [DatabaseException] should be thrownBy await(repository.save(notUpsert))
+    }
+  }
+
   "Creation of Indexes" should {
     "should be done based on provided Indexes" in new LogCapturing {
       await(repository.drop)


### PR DESCRIPTION
ReactiveRepository#save has been deprecated in favour of insert as save will do an update under the hood and it is believed that is not the desired behaviour that projects require.

ReactiveRepository#save now calls ReactiveRepository#insert to ensure previous behaviour is upheld