### PR TITLE
Limit Queries

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -42,12 +42,12 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
     collection.find(Json.obj(query: _*)).cursor[A](ReadPreference.secondaryPreferred).collect[List]() //TODO: pass in ReadPreference
   }
 
-  override def findAll(readPreference: ReadPreference = ReadPreference.secondaryPreferred, pageSize: Option[Int] = None, fromId: Option[ID] = None)
+  override def findAll(readPreference: ReadPreference = ReadPreference.secondaryPreferred, limit: Option[Int] = None, afterId: Option[ID] = None)
                       (implicit ec: ExecutionContext): Future[List[A]] = {
-    val query = fromId.map(id => Json.obj("_id" -> Json.obj("$gt" -> id))).getOrElse(Json.obj())
-    val limit = pageSize.getOrElse(Int.MaxValue)
+    val query = afterId.map(id => Json.obj("_id" -> Json.obj("$gt" -> id))).getOrElse(Json.obj())
+    val size = limit.getOrElse(Int.MaxValue)
 
-    collection.find(query).cursor[A](readPreference).collect[List](limit)
+    collection.find(query).cursor[A](readPreference).collect[List](size)
   }
 
   override def findById(id: ID, readPreference: ReadPreference = ReadPreference.secondaryPreferred)(implicit ec: ExecutionContext): Future[Option[A]] = {

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -6,6 +6,7 @@ import play.api.libs.json.{Format, JsObject, Json}
 import reactivemongo.api.commands._
 import reactivemongo.api.indexes.Index
 import reactivemongo.api.{DB, ReadPreference}
+import reactivemongo.bson.BSONDocument
 import reactivemongo.core.commands.Count
 import reactivemongo.core.errors.{GenericDatabaseException, DetailedDatabaseException, DatabaseException}
 import reactivemongo.json.ImplicitBSONHandlers
@@ -47,7 +48,7 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
     val query = afterId.map(id => Json.obj("_id" -> Json.obj("$gt" -> id))).getOrElse(Json.obj())
     val size = limit.getOrElse(Int.MaxValue)
 
-    collection.find(query).cursor[A](readPreference).collect[List](size)
+    collection.find(query).sort(Json.obj("_id" -> 1)).cursor[A](readPreference).collect[List](size)
   }
 
   override def findById(id: ID, readPreference: ReadPreference = ReadPreference.secondaryPreferred)(implicit ec: ExecutionContext): Future[Option[A]] = {

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -42,8 +42,12 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
     collection.find(Json.obj(query: _*)).cursor[A](ReadPreference.secondaryPreferred).collect[List]() //TODO: pass in ReadPreference
   }
 
-  override def findAll(readPreference: ReadPreference = ReadPreference.secondaryPreferred)(implicit ec: ExecutionContext): Future[List[A]] = {
-    collection.find(Json.obj()).cursor[A](readPreference).collect[List]()
+  override def findAll(readPreference: ReadPreference = ReadPreference.secondaryPreferred, pageSize: Option[Int] = None, fromId: Option[ID] = None)
+                      (implicit ec: ExecutionContext): Future[List[A]] = {
+    val query = fromId.map(id => Json.obj("_id" -> Json.obj("$gt" -> id))).getOrElse(Json.obj())
+    val limit = pageSize.getOrElse(Int.MaxValue)
+
+    collection.find(query).cursor[A](readPreference).collect[List](limit)
   }
 
   override def findById(id: ID, readPreference: ReadPreference = ReadPreference.secondaryPreferred)(implicit ec: ExecutionContext): Future[Option[A]] = {

--- a/src/main/scala/uk/gov/hmrc/mongo/Repository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/Repository.scala
@@ -33,7 +33,8 @@ trait Repository[A <: Any, ID <: Any] extends CurrentTime {
 
   import reactivemongo.api.ReadPreference
 
-  def findAll(readPreference: ReadPreference = ReadPreference.secondaryPreferred)(implicit ec: ExecutionContext): Future[List[A]] = ???
+  def findAll(readPreference: ReadPreference = ReadPreference.secondaryPreferred, pageSize: Option[Int] = None, fromId: Option[ID] = None)
+             (implicit ec: ExecutionContext): Future[List[A]] = ???
 
   def findById(id: ID, readPreference: ReadPreference = ReadPreference.secondaryPreferred)(implicit ec: ExecutionContext): Future[Option[A]] = ???
 

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
@@ -122,7 +122,7 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
       await(created) shouldBe 6
 
-      val result = await(repository.findAll(pageSize = Some(5)))
+      val result = await(repository.findAll(limit = Some(5)))
       result.size shouldBe 5
       result should contain(e1)
       result should contain(e2)
@@ -146,7 +146,7 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
       await(created) shouldBe 6
 
-      val result = await(repository.findAll(fromId = Some(e5.id)))
+      val result = await(repository.findAll(afterId = Some(e5.id)))
       result.size shouldBe 1
       result should not contain e5
       result should contain(e6)


### PR DESCRIPTION
Based on the feedback for this pull request: https://github.com/hmrc/simple-reactivemongo/pull/36

I also work for the VOA, and I have modified findAll so that it now takes two optional parameters, to allow pagination. 

Let me know if I've overlooked something or if you want me to make any changes.