### PR TITLE
Remove the need for adding an implicit ExecutionContext from ReactiveRepository Constructor

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -18,7 +18,8 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
                                                        mongo: () => DB,
                                                        domainFormat: Format[A],
                                                        idFormat: Format[ID] = ReactiveMongoFormats.objectIdFormats,
-                                                       mc: Option[JSONCollection] = None)
+                                                       mc: Option[JSONCollection] = None,
+                                                       ecForInitialIndexChecks: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global)
                                                       (implicit manifest: Manifest[A], mid: Manifest[ID])
   extends Repository[A, ID] with Indexes with ImplicitBSONHandlers {
 
@@ -32,7 +33,7 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
   protected val logger = LoggerFactory.getLogger(this.getClass)
   val message: String = "Failed to ensure index"
 
-  ensureIndexes(scala.concurrent.ExecutionContext.Implicits.global)
+  ensureIndexes(ecForInitialIndexChecks)
 
   protected val _Id = "_id"
   protected def _id(id : ID) = Json.obj(_Id -> id)

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -19,7 +19,7 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
                                                        domainFormat: Format[A],
                                                        idFormat: Format[ID] = ReactiveMongoFormats.objectIdFormats,
                                                        mc: Option[JSONCollection] = None,
-                                                       ecForInitialIndexChecks: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global)
+                                                       initialisingEc: ExecutionContext = scala.concurrent.ExecutionContext.global)
                                                       (implicit manifest: Manifest[A], mid: Manifest[ID])
   extends Repository[A, ID] with Indexes with ImplicitBSONHandlers {
 
@@ -33,7 +33,7 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
   protected val logger = LoggerFactory.getLogger(this.getClass)
   val message: String = "Failed to ensure index"
 
-  ensureIndexes(ecForInitialIndexChecks)
+  ensureIndexes(initialisingEc)
 
   protected val _Id = "_id"
   protected def _id(id : ID) = Json.obj(_Id -> id)

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -14,13 +14,12 @@ import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 import scala.concurrent.{ExecutionContext, Future}
 
-
 abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
                                                        mongo: () => DB,
                                                        domainFormat: Format[A],
                                                        idFormat: Format[ID] = ReactiveMongoFormats.objectIdFormats,
                                                        mc: Option[JSONCollection] = None)
-                                                      (implicit manifest: Manifest[A], mid: Manifest[ID], ec : ExecutionContext)
+                                                      (implicit manifest: Manifest[A], mid: Manifest[ID])
   extends Repository[A, ID] with Indexes with ImplicitBSONHandlers {
 
   import play.api.libs.json.Json.JsValueWrapper
@@ -33,7 +32,7 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
   protected val logger = LoggerFactory.getLogger(this.getClass)
   val message: String = "Failed to ensure index"
 
-  ensureIndexes
+  ensureIndexes(scala.concurrent.ExecutionContext.Implicits.global)
 
   protected val _Id = "_id"
   protected def _id(id : ID) = Json.obj(_Id -> id)
@@ -78,7 +77,6 @@ abstract class ReactiveRepository[A <: Any, ID <: Any](collectionName: String,
           Future.failed[WriteResult](new Exception("cannot write object"))
       }
   }
-
 
   private val DuplicateKeyError = "E11000"
   private def ensureIndex(index: Index)(implicit ec: ExecutionContext): Future[Boolean] = {


### PR DESCRIPTION
This is related to #48 