### PR TITLE
hmrc/reactivemongo 0.14.0 and official reactivemongo-play-json

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -38,11 +38,10 @@ object HmrcBuild extends Build {
 object Dependencies {
 
   object Compile {
-    val reactiveMongoJson = "uk.gov.hmrc" %% "reactivemongo-json" % "3.2.0"
+    val reactiveMongoJson = "org.reactivemongo" %% "reactivemongo-play-json" % "0.12.6-play25"
     //NOTE: 0.11.6 Netty 3.10.4.Final clashes with Play (2.3.10) version of Netty 3.9.8
 
-    // USING HMRC FORK OF REACTIVEMONGO - https://github.com/hmrc/ReactiveMongo
-    val reactiveMongo = "uk.gov.hmrc" %% "reactivemongo" % "0.13.0"
+    val reactiveMongo = "uk.gov.hmrc" %% "reactivemongo" % "0.14.0"
 
     val playJson = "com.typesafe.play" %% "play-json" % "2.5.12" % "provided"
     val nscalaTime = "com.github.nscala-time" %% "nscala-time" % "2.2.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.15

--- a/src/main/scala/reactivemongo/ReactiveMongoHelper.scala
+++ b/src/main/scala/reactivemongo/ReactiveMongoHelper.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactivemongo
+
+import reactivemongo.core.nodeset.Authenticate
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import reactivemongo.api._
+
+object ReactiveMongoHelper {
+
+  @deprecated(message = "use case class constructor that takes MongoConnectionOptions")
+  def apply(dbName: String,
+            servers: Seq[String],
+            auth: Seq[Authenticate],
+            nbChannelsPerNode: Option[Int],
+            failoverStrategy: Option[FailoverStrategy]):ReactiveMongoHelper = {
+    val mongoOpts = nbChannelsPerNode.map { n => MongoConnectionOptions().copy(nbChannelsPerNode = n) }.getOrElse(MongoConnectionOptions())
+    this(dbName, servers, auth, failoverStrategy, mongoOpts)
+  }
+}
+
+case class ReactiveMongoHelper(dbName: String,
+                               servers: Seq[String],
+                               auth: Seq[Authenticate],
+                               failoverStrategy: Option[FailoverStrategy],
+                               connectionOptions: MongoConnectionOptions = MongoConnectionOptions()) {
+
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+  lazy val driver = new MongoDriver
+
+  lazy val connection = driver.connection(
+    servers,
+    authentications = auth,
+    options = connectionOptions
+  )
+
+  import scala.concurrent.duration._
+  lazy val db: DefaultDB = failoverStrategy match {
+    case Some(fs : FailoverStrategy) => Await.result(connection.database(dbName, fs), 10 seconds)
+    case None => Await.result(connection.database(dbName), 10 seconds)
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/mongo/AtomicUpdate.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/AtomicUpdate.scala
@@ -1,10 +1,10 @@
 package uk.gov.hmrc.mongo
 
-import play.api.libs.json.{Writes, Reads, JsSuccess, JsError, JsResultException}
+import play.api.libs.json.{Reads, JsSuccess, JsError, JsResultException}
 import reactivemongo.bson.{BSONObjectID, BSONDocument}
 import reactivemongo.core.commands.{LastError, Update, FindAndModify}
-import reactivemongo.json.ImplicitBSONHandlers.JsObjectReader
-import reactivemongo.json.collection.JSONCollection
+import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectReader
+import reactivemongo.play.json.collection.JSONCollection
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/uk/gov/hmrc/mongo/SimpleMongoConnection.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/SimpleMongoConnection.scala
@@ -19,7 +19,7 @@ trait SimpleMongoConnection {
 
   private def connect = helper.db
 
-  lazy val helper = MongoConnection.parseURI(mongoConnectionUri) match {
+  lazy val helper: ReactiveMongoHelper = MongoConnection.parseURI(mongoConnectionUri) match {
     case Success(MongoConnection.ParsedURI(hosts, options, ignoreOptions, Some(db), auth)) =>
       ReactiveMongoHelper(db, hosts.map(h => h._1 + ":" + h._2), auth.toList, failoverStrategy, options)
     case Success(MongoConnection.ParsedURI(_, _, _, None, _)) =>

--- a/src/main/scala/uk/gov/hmrc/mongo/geospatial/Geospatial.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/geospatial/Geospatial.scala
@@ -11,6 +11,7 @@ trait Geospatial[A, ID] {
   import play.api.libs.json.Json
   import reactivemongo.api.indexes.Index
   import reactivemongo.api.indexes.IndexType.Geo2DSpherical
+  import reactivemongo.play.json.ImplicitBSONHandlers._
 
   lazy val LocationField = "loc"
 

--- a/src/main/scala/uk/gov/hmrc/mongo/json/ExtraBSONHandlers.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/json/ExtraBSONHandlers.scala
@@ -10,7 +10,7 @@ trait ExtraBSONHandlers {
     new BSONDocumentReader[Map[String, T]] {
     def read(doc: BSONDocument): Map[String, T] = {
       doc.elements.collect {
-        case (key, value) => value.seeAsOpt[T](reader) map {
+        case BSONElement(key, value) => value.seeAsOpt[T](reader) map {
           ov => (key, ov)
         }
       }.flatten.toMap

--- a/src/test/scala/uk/gov/hmrc/mongo/MongoConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/MongoConnectorSpec.scala
@@ -10,9 +10,9 @@ import org.scalatest.{Matchers, WordSpec}
 class MongoConnectorSpec extends WordSpec with Matchers  {
 
   "MongoConnector" should {
-    "create a Mongo connection with the given options" in {
+    "create a Mongo connection with the given options" in  {
 
-      val connector = MongoConnector("mongodb://mongo-host:2000/mongo?connectTimeoutMS=1000&socketTimeoutMS=2000", failoverStrategy = None)
+      val connector = MongoConnector("mongodb://127.0.0.1:27017/test?connectTimeoutMS=1000&socketTimeoutMS=2000", failoverStrategy = None)
 
       connector.db().connection.options.connectTimeoutMS shouldBe 1000
     }

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
@@ -136,7 +136,10 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
       await(repository.save(e1))
 
-      await(repository.removeById(e1.id)).inError shouldBe false
+      val removeResult = await(repository.removeById(e1.id))
+      val inError = !removeResult.ok || removeResult.code.isDefined
+
+      inError shouldBe false
 
       val result: Option[TestObject] = await(repository.findById(e1.id))
       result should be(None)
@@ -151,7 +154,9 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
       await(repository.save(e1))
 
-      await(repository.remove("anotherField" -> "used to identify")).inError shouldBe false
+      val removeResult = await(repository.remove("anotherField" -> "used to identify"))
+      val inError = !removeResult.ok || removeResult.code.isDefined
+      inError shouldBe false
 
       val result: Option[TestObject] = await(repository.findById(e1.id))
       result should be(None)
@@ -165,7 +170,9 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
       await(repository.save(e1))
 
-      await(repository.remove("_id" -> e1.id, "anotherField" -> "used to identify")).inError shouldBe false
+      val removeResult = await(repository.remove("_id" -> e1.id, "anotherField" -> "used to identify"))
+      val inError = !removeResult.ok || removeResult.code.isDefined
+      inError shouldBe false
 
       val result: Option[TestObject] = await(repository.findById(e1.id))
       result should be(None)
@@ -233,7 +240,7 @@ class ReactiveRepositorySpec extends WordSpec with Matchers with MongoSpecSuppor
 
         await(uniqueIndexRepository.ensureIndexes) shouldBe Seq(false)
         logList.size should be(1)
-        logList.head.getMessage shouldBe (uniqueIndexRepository.message)
+        logList.head.getMessage contains uniqueIndexRepository.message
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/mongo/SleepyProxy.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/SleepyProxy.scala
@@ -4,12 +4,12 @@ import java.net.InetSocketAddress
 import java.util.concurrent.{ Executors, ExecutorService }
 import java.util.concurrent.atomic.AtomicLong
 
-import org.jboss.netty.bootstrap.{ ClientBootstrap, ServerBootstrap }
-import org.jboss.netty.buffer.{ ChannelBuffers, ChannelBuffer }
-import org.jboss.netty.channel.Channels._
-import org.jboss.netty.channel._
-import org.jboss.netty.channel.socket.ClientSocketChannelFactory
-import org.jboss.netty.channel.socket.nio.{ NioClientSocketChannelFactory, NioServerSocketChannelFactory }
+import shaded.netty.bootstrap.{ ClientBootstrap, ServerBootstrap }
+import shaded.netty.buffer.{ ChannelBuffers, ChannelBuffer }
+import shaded.netty.channel.Channels._
+import shaded.netty.channel._
+import shaded.netty.channel.socket.ClientSocketChannelFactory
+import shaded.netty.channel.socket.nio.{ NioClientSocketChannelFactory, NioServerSocketChannelFactory }
 
 case class SleepyProxyContext(
     sb: ServerBootstrap,


### PR DESCRIPTION
- Moved `ReactiveMongoHelper` from reactivemongo-json to simple-reactivemongo
- Avoiding race connection when creating connection in `ReactiveMongoHelper`
- Removing our own version of reactivemongo-json and using official reactivemongo-play-json
- Optimised import, fixed MongoConnectorSpec
- Using `ImplicitBSONHandlers` object for imports now that the `trait` is back to being a `sealed trait` and it's no longer mixed in with `ReactiveRepository`. Doing it this way means we can deprecate our version of reactivemongo in favour of official reactivemongo in the future. This means that teams must also do this in certain parts of their code