### PR TITLE
Add translation layer from log4j to slf4j

### DIFF
--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -12,6 +12,7 @@ object LibraryDependencies {
     ),
     play25 = Seq(
       "org.slf4j"         % "slf4j-api"                % "1.7.21",
+      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.21",
       "com.typesafe.play" %% "play"                    % play25Version,
       "org.reactivemongo" %% "reactivemongo-play-json" % "0.16.0-play25",
       // force dependencies due to security flaws found in jackson-databind < 2.9.x using XRay
@@ -25,6 +26,7 @@ object LibraryDependencies {
     ),
     play26 = Seq(
       "org.slf4j"         % "slf4j-api"                % "1.7.25",
+      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.25",
       "com.typesafe.play" %% "play"                    % play26Version,
       "com.typesafe.play" %% "play-guice"              % play26Version,
       "org.reactivemongo" %% "reactivemongo-play-json" % "0.16.0-play26"


### PR DESCRIPTION
It is [required by documentation  in 'Troubleshooting' section][1] and cause [problems with linking][3].
Netty in 4.0 line have [problems with missing log4j on classpath too][2].

[1]: http://reactivemongo.org/releases/0.1x/documentation/tutorial/setup.html
[2]: https://github.com/netty/netty/issues/8217
[3]: https://github.com/ReactiveMongo/ReactiveMongo/issues/780