### PR TITLE
BDOG-114 make it possible to configure the default 10s timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ class SimpleTestRepository @Inject()(mongoComponent: ReactiveMongoComponent)
 
 Formats for BSONObjectId and Joda time classes are implemented (see [ReactiveMongoFormats](https://github.com/hmrc/simple-reactivemongo/blob/master/src/main/scala/uk/gov/hmrc/mongo/ReactiveMongoFormats.scala))
 
+#### Configuration Options
+
+There is a default timeout of 10 seconds when making connections with Mongo. This value is 
+configurable by setting the key:
+
+`mongodb.dbTimeoutMsecs=10000`
+
+Within your application.conf
+
 #### Configure underlying Akka system
 
 ReactiveMongo loads it's configuration from the key `mongo-async-driver`

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -11,22 +11,22 @@ object LibraryDependencies {
       "org.reactivemongo"      %% "reactivemongo" % "0.16.1"
     ),
     play25 = Seq(
-      "org.slf4j"         % "slf4j-api"                % "1.7.21",
-      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.21",
+      "org.slf4j"         % "slf4j-api"                % "1.7.26",
+      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.26",
       "com.typesafe.play" %% "play"                    % play25Version,
       "org.reactivemongo" %% "reactivemongo-play-json" % "0.16.0-play25",
       // force dependencies due to security flaws found in jackson-databind < 2.9.x using XRay
-      "com.fasterxml.jackson.core"     % "jackson-core"            % "2.9.7",
-      "com.fasterxml.jackson.core"     % "jackson-databind"        % "2.9.7",
-      "com.fasterxml.jackson.core"     % "jackson-annotations"     % "2.9.7",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8"   % "2.9.7",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.7",
+      "com.fasterxml.jackson.core"     % "jackson-core"            % "2.9.8",
+      "com.fasterxml.jackson.core"     % "jackson-databind"        % "2.9.8",
+      "com.fasterxml.jackson.core"     % "jackson-annotations"     % "2.9.8",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8"   % "2.9.8",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.9.8",
       // force dependencies due to security flaws found in xercesImpl 2.11.0
       "xerces" % "xercesImpl" % "2.12.0"
     ),
     play26 = Seq(
-      "org.slf4j"         % "slf4j-api"                % "1.7.25",
-      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.25",
+      "org.slf4j"         % "slf4j-api"                % "1.7.26",
+      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.26",
       "com.typesafe.play" %% "play"                    % play26Version,
       "com.typesafe.play" %% "play-guice"              % play26Version,
       "org.reactivemongo" %% "reactivemongo-play-json" % "0.16.0-play26"
@@ -37,9 +37,9 @@ object LibraryDependencies {
     shared = Seq(
       "com.outworkers" %% "util-samplers"  % "0.40.0" % Test,
       "org.pegdown"    % "pegdown"         % "1.6.0"  % Test,
-      "org.scalacheck" %% "scalacheck"     % "1.13.4" % Test,
+      "org.scalacheck" %% "scalacheck"     % "1.13.5" % Test,
       "org.scalamock"  %% "scalamock"      % "4.1.0"  % Test,
-      "org.scalatest"  %% "scalatest"      % "3.0.5"  % Test,
+      "org.scalatest"  %% "scalatest"      % "3.0.6"  % Test,
       "ch.qos.logback" % "logback-classic" % "1.2.3"  % Test
     ),
     play25 = Seq(

--- a/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
@@ -58,6 +58,10 @@ class MongoConfig(
       case _ => None
     }
 
+  lazy val dbTimeout: Option[FiniteDuration] =
+    mongoConfig.getOptional[Long]("dbTimeoutMsecs")
+        .map(dbTimeout => new FiniteDuration(dbTimeout, TimeUnit.MILLISECONDS))
+
   private lazy val mongoConfig: Configuration = configuration
     .getOptional[Configuration]("mongodb")
     .orElse(configuration.getOptional[Configuration](s"${environment.mode}.mongodb"))

--- a/src/main/scala/play/modules/reactivemongo/ReactiveMongoHmrcModule.scala
+++ b/src/main/scala/play/modules/reactivemongo/ReactiveMongoHmrcModule.scala
@@ -52,8 +52,11 @@ class ReactiveMongoComponentImpl @Inject()(
 
   lazy val mongoConnector: MongoConnector = MongoConnector(
     mongoConfig.uri,
-    mongoConfig.maybeFailoverStrategy
+    mongoConfig.maybeFailoverStrategy,
+    mongoConfig.dbTimeout
   )
+
+  Logger.debug(s"ReactiveMongoPlugin: MongoConnector configuration being used: $mongoConnector")
 
   lifecycle.addStopHook { () =>
     Future.successful {

--- a/src/test/scala/play/modules/reactivemongo/MongoConfigSpec.scala
+++ b/src/test/scala/play/modules/reactivemongo/MongoConfigSpec.scala
@@ -99,6 +99,15 @@ class MongoConfigSpec extends WordSpec with MockFactory with PropertyChecks {
       s"return None for 'maybeFailoverStrategy' if '$mongodbConfigKey.failoverStrategy' not present in config" in new Setup {
         mongoConfig(mongodbConfigKey -> Map.empty).maybeFailoverStrategy shouldBe None
       }
+
+      s"return None for 'dbTimeoutMsecs' if '$mongodbConfigKey.dbTimeoutMsecs' not present in config" in new Setup {
+        mongoConfig(mongodbConfigKey -> Map.empty).dbTimeout shouldBe None
+      }
+
+      s"override 'dbTimeoutMsecs' if specified under '$mongodbConfigKey.dbTimeoutMsecs'" in new Setup {
+        val dbTimeout = mongoConfig(s"$mongodbConfigKey.dbTimeoutMsecs" -> dbTimeoutMsecs).dbTimeout
+        dbTimeout shouldBe Some(new FiniteDuration(dbTimeoutMsecs, MILLISECONDS))
+      }
     }
   }
 
@@ -108,6 +117,7 @@ class MongoConfigSpec extends WordSpec with MockFactory with PropertyChecks {
     val uri                       = "mongouri"
     val channels                  = 1
     val initialDelayMsecs         = 1234
+    val dbTimeoutMsecs            = 1234
     val retries                   = 5
 
     def mongoConfig(configEntries: (String, Any)*): MongoConfig =


### PR DESCRIPTION
This PR makes it possible to configure the default 10s timeout on the futures when talking with Mongo, by setting the config key:

mongodb.dbTimeoutMsecs