### PR TITLE
BDOG-538 adds optional network diagnostics, updates .count

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
@@ -67,6 +67,8 @@ class MongoConfig(
     .orElse(configuration.getOptional[Configuration](s"${environment.mode}.mongodb"))
     .orElse(configuration.getOptional[Configuration](s"${Mode.Dev}.mongodb"))
     .getOrElse(throw new Exception("The application does not contain required mongodb configuration"))
+
+  lazy val diagnostics: Boolean = mongoConfig.getBoolean("diagnostics").getOrElse(false)
 }
 
 private object DelayFactor extends (Option[Configuration] => Int => Double) {

--- a/src/main/scala/play/modules/reactivemongo/ReactiveMongoHmrcModule.scala
+++ b/src/main/scala/play/modules/reactivemongo/ReactiveMongoHmrcModule.scala
@@ -16,12 +16,16 @@
 
 package play.modules.reactivemongo
 
+import java.net.{InetAddress, Socket}
+
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import play.api._
 import play.api.inject.{ApplicationLifecycle, Binding, Module}
+import reactivemongo.api.MongoConnection
 import uk.gov.hmrc.mongo.MongoConnector
 
 import scala.concurrent.Future
+import scala.util.{Failure, Try}
 
 class ReactiveMongoHmrcModule extends Module {
   def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =
@@ -50,12 +54,17 @@ class ReactiveMongoComponentImpl @Inject()(
 
   private lazy val mongoConfig = new MongoConfig(environment, configuration)
 
-  lazy val mongoConnector: MongoConnector = MongoConnector(
-    mongoConfig.uri,
-    mongoConfig.maybeFailoverStrategy,
-    mongoConfig.dbTimeout
-  )
+  val mongoConnector: MongoConnector = {
 
+    if(mongoConfig.diagnostics) MongoDiagnostics.runAll(mongoConfig)
+
+    MongoConnector(
+      mongoConfig.uri,
+      mongoConfig.maybeFailoverStrategy,
+      mongoConfig.dbTimeout
+    )
+
+  }
   Logger.debug(s"ReactiveMongoPlugin: MongoConnector configuration being used: $mongoConnector")
 
   lifecycle.addStopHook { () =>
@@ -64,4 +73,51 @@ class ReactiveMongoComponentImpl @Inject()(
       mongoConnector.close()
     }
   }
+}
+
+object MongoDiagnostics {
+
+  def runAll(config: MongoConfig):Unit = Try {
+    Logger.info("Running mongo diagnostics")
+    logConfig(config)
+    validateDNS(config)
+    validateNetworkConnectivity(config)
+    Logger.info("Mongo diagnostics complete")
+  }
+
+  private def logConfig(config: MongoConfig): Unit = {
+    MongoConnection.parseURI(config.uri)
+      .foreach(puri => {
+        Logger.info(s"Mongo auth set: ${puri.authenticate.isDefined}")
+        Logger.info(s"Mongo database: ${puri.db.getOrElse("Not Set")}")
+        Logger.info(s"Mongo nodelist: ${puri.hosts.mkString(",")}")
+      })
+  }
+
+  private def validateDNS(config: MongoConfig):Unit = {
+    MongoConnection.parseURI(config.uri).foreach { parsedUri =>
+      parsedUri.hosts.map(_._1).foreach { host =>
+        InetAddress.getAllByName(host).map(_.getAddress.map(_.toInt).mkString(".")).foreach(ip => Logger.info(s"Mongo node [$host] resolves to $ip"))
+      }
+    }
+  }
+
+  private def validateNetworkConnectivity(mongoConfig: MongoConfig) : Unit = Try {
+      Logger.info("Testing mongo network connectivity...")
+      MongoConnection.parseURI(mongoConfig.uri).foreach { parsedUri =>
+        parsedUri.hosts.foreach( hp => validateConnection(hp._1, hp._2))
+    }
+  }
+
+  private def validateConnection(host:String, port:Int): Unit = Try {
+    val s = new Socket(host, port)
+    Logger.info(s"[$host:$port](${s.getInetAddress.toString}) connected: ${s.isConnected}, is network reachable: ${Try(s.getInetAddress.isReachable(20)).getOrElse(false)}")
+    s.close()
+  }.recoverWith {
+    case ex: Throwable => {
+      Logger.info(s"[$host:$port] Mongo network connectivity failed")
+      Failure(ex)
+    }
+  }
+
 }


### PR DESCRIPTION
Reactive-mongo 0.18.x deprecated the .count method used in simple reactive mongo. Also added in some optional diagnostics to test network connectivity on startup displaying some of the config, the node list and the IP addresses and a simple connectivity check to each node. This is off by default, enabled via the config.