### PR TITLE
Pin commons-codec to 1.12, due to Base64 handling changes

### DIFF
--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -8,7 +8,10 @@ object LibraryDependencies {
   val compile: Seq[ModuleID] = PlayCrossCompilation.dependencies(
     shared = Seq(
       "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
-      "org.reactivemongo"      %% "reactivemongo" % "0.18.8"
+      "org.reactivemongo"      %% "reactivemongo" % "0.18.8",
+      // force commons-codec to avoid 1.13 and 1.14 until 1.15 is available
+      // see JIRA ticket BDOG-612
+      "commons-codec"          %  "commons-codec" % "1.12" force()
     ),
     play25 = Seq(
       "org.slf4j"         % "slf4j-api"                % "1.7.26",

--- a/src/main/play-25/play/modules/reactivemongo/ValueFinder.scala
+++ b/src/main/play-25/play/modules/reactivemongo/ValueFinder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/play/modules/reactivemongo/MongoDbConnection.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoDbConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/play/modules/reactivemongo/ReactiveMongoHmrcModule.scala
+++ b/src/main/scala/play/modules/reactivemongo/ReactiveMongoHmrcModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/reactivemongo/ReactiveMongoHelper.scala
+++ b/src/main/scala/reactivemongo/ReactiveMongoHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/AtomicUpdate.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/AtomicUpdate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/BSONBuilderHelpers.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/BSONBuilderHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/CreationAndLastModifiedDetail.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/CreationAndLastModifiedDetail.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/CurrentTime.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/CurrentTime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/ReactiveRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/SimpleMongoConnection.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/SimpleMongoConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/geospatial/Coordinates.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/geospatial/Coordinates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/geospatial/Geospatial.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/geospatial/Geospatial.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/json/BSONObjectIdFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/json/BSONObjectIdFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/json/ExtraBSONHandlers.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/json/ExtraBSONHandlers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/json/JsonExtensions.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/json/JsonExtensions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/json/ReactiveMongoFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/json/ReactiveMongoFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/mongo/json/TupleFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/json/TupleFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/play/modules/reactivemongo/DelayFactorSpec.scala
+++ b/src/test/scala/play/modules/reactivemongo/DelayFactorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/play/modules/reactivemongo/InjectionSpec.scala
+++ b/src/test/scala/play/modules/reactivemongo/InjectionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/play/modules/reactivemongo/MongoConfigSpec.scala
+++ b/src/test/scala/play/modules/reactivemongo/MongoConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/AtomicUpdateSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/AtomicUpdateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/CreationAndLastModifiedDetailSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/CreationAndLastModifiedDetailSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/FindAndUpdateSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/FindAndUpdateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/MongoConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/MongoConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/MongoMatchersAndTypeClasses.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/MongoMatchersAndTypeClasses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/MongoSpecSupport.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/MongoSpecSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/ReactiveRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/geospatial/GeospatialSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/geospatial/GeospatialSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/json/BsonObjectIdFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/json/BsonObjectIdFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/mongo/json/ReactiveMongoFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mongo/json/ReactiveMongoFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
We recently upgraded the reactivemongo dependency in this project, to fix a bug with signalling channel initialisation. Whilst that got fixed, it surfaced another 'issue', by bringing in the apache commons-codec 1.13.

Commons-codec 1.13 subtly changed the way that Base64 got decoded, when the string being decoded was invalid. If it was completely invalid, it would error. However, there are certain strings that are not valid Base64, but can be decoded as if they were. I won't try and explain the detail here (more detail is on the first JIRA ticket linked below), but it seems to involve the last few characters of a string - in that Base64 decoders can discard/pad them. However, if you randomly change the last few characters of a Base64 string, chances are that you just made it invalid.

Anyway, commons-codec 1.12 was lenient to this. 1.13 is not, and neither is 1.14. 1.15 will be, but it is not currently released.

See these relevant JIRAS:
https://issues.apache.org/jira/browse/CODEC-263
https://issues.apache.org/jira/browse/CODEC-270
https://issues.apache.org/jira/browse/CODEC-280

This change in behaviour has surfaced various encoding/decoding scenarios where we relied on an invalid Base64 string, but it was being used leniently. Whilst it is a good thing that spot, and fix, these invalid Base64 occurrences, it has been causing lots of noise. Therefore, this PR reverts the upgrade to 1.13 and forces the use of 1.12. It is intended that we release a new version of this library when apache commons-codec 1.15 is released, provided that changes for XXX are contained within in.

Phew.