### PR TITLE
BDOG-657 Bump reactivemongo to 0.20.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - scala: 2.12.8
       env: PLAY_VERSION=2.6
       jdk: openjdk8
+    - scala: 2.12.8
+      env: PLAY_VERSION=2.7
+      jdk: openjdk8
 
 notifications:
   email:

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -3,19 +3,20 @@ import sbt._
 object LibraryDependencies {
 
   private val play25Version = "2.5.19"
-  private val play26Version = "2.6.20"
+  private val play26Version = "2.6.23" // this version is pinned, since later versions are incompatible with the version of akka that reactivemongo was build with on scala 2.11.
+  private val play27Version = "2.7.4"
 
   val compile: Seq[ModuleID] = PlayCrossCompilation.dependencies(
     shared = Seq(
-      "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
-      "org.reactivemongo"      %% "reactivemongo" % "0.20.2",
+      "com.github.nscala-time" %% "nscala-time"      % "2.22.0",
+      "org.reactivemongo"      %% "reactivemongo"    % "0.20.2",
+      "org.slf4j"              %  "slf4j-api"        % "1.7.26",
+      "org.slf4j"              %  "log4j-over-slf4j" % "1.7.26",
       // force commons-codec to avoid 1.13 and 1.14 until 1.15 is available
       // see JIRA ticket BDOG-612
       "commons-codec"          %  "commons-codec" % "1.12" force()
     ),
     play25 = Seq(
-      "org.slf4j"         % "slf4j-api"                % "1.7.26",
-      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.26",
       "com.typesafe.play" %% "play"                    % play25Version,
       "org.reactivemongo" %% "reactivemongo-play-json" % "0.20.2-play25",
       // force dependencies due to security flaws found in jackson-databind < 2.9.x using XRay
@@ -28,11 +29,14 @@ object LibraryDependencies {
       "xerces" % "xercesImpl" % "2.12.0"
     ),
     play26 = Seq(
-      "org.slf4j"         % "slf4j-api"                % "1.7.26",
-      "org.slf4j"         % "log4j-over-slf4j"         % "1.7.26",
       "com.typesafe.play" %% "play"                    % play26Version,
       "com.typesafe.play" %% "play-guice"              % play26Version,
       "org.reactivemongo" %% "reactivemongo-play-json" % "0.20.2-play26"
+    ),
+    play27 = Seq(
+      "com.typesafe.play" %% "play"                    % play27Version,
+      "com.typesafe.play" %% "play-guice"              % play27Version,
+      "org.reactivemongo" %% "reactivemongo-play-json" % "0.20.2-play27"
     )
   )
 
@@ -51,6 +55,10 @@ object LibraryDependencies {
     ),
     play26 = Seq(
       "com.typesafe.play"      %% "play-test"          % play26Version % Test,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2"       % Test
+    ),
+    play27 = Seq(
+      "com.typesafe.play"      %% "play-test"          % play27Version % Test,
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2"       % Test
     )
   )

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -8,7 +8,7 @@ object LibraryDependencies {
   val compile: Seq[ModuleID] = PlayCrossCompilation.dependencies(
     shared = Seq(
       "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
-      "org.reactivemongo"      %% "reactivemongo" % "0.19.7",
+      "org.reactivemongo"      %% "reactivemongo" % "0.20.2",
       // force commons-codec to avoid 1.13 and 1.14 until 1.15 is available
       // see JIRA ticket BDOG-612
       "commons-codec"          %  "commons-codec" % "1.12" force()
@@ -17,7 +17,7 @@ object LibraryDependencies {
       "org.slf4j"         % "slf4j-api"                % "1.7.26",
       "org.slf4j"         % "log4j-over-slf4j"         % "1.7.26",
       "com.typesafe.play" %% "play"                    % play25Version,
-      "org.reactivemongo" %% "reactivemongo-play-json" % "0.19.7-play25",
+      "org.reactivemongo" %% "reactivemongo-play-json" % "0.20.2-play25",
       // force dependencies due to security flaws found in jackson-databind < 2.9.x using XRay
       "com.fasterxml.jackson.core"     % "jackson-core"            % "2.9.8",
       "com.fasterxml.jackson.core"     % "jackson-databind"        % "2.9.8",
@@ -32,7 +32,7 @@ object LibraryDependencies {
       "org.slf4j"         % "log4j-over-slf4j"         % "1.7.26",
       "com.typesafe.play" %% "play"                    % play26Version,
       "com.typesafe.play" %% "play-guice"              % play26Version,
-      "org.reactivemongo" %% "reactivemongo-play-json" % "0.19.7-play26"
+      "org.reactivemongo" %% "reactivemongo-play-json" % "0.20.2-play26"
     )
   )
 

--- a/project/PlayCrossCompilation.scala
+++ b/project/PlayCrossCompilation.scala
@@ -1,4 +1,12 @@
 import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
-import uk.gov.hmrc.playcrosscompilation.PlayVersion.Play25
+import uk.gov.hmrc.playcrosscompilation.PlayVersion
 
-object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play25)
+object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = PlayVersion.Play25) {
+   override def playCrossScalaBuilds(scalaVersions: Seq[String]): Seq[String] =
+     playVersion match {
+       case PlayVersion.Play25 => scalaVersions.filter(version => version.startsWith("2.11"))
+       case PlayVersion.Play26 => scalaVersions
+       case PlayVersion.Play27 => // reactivemongo uses an old akka-version which is incompatible with the latter version of akka used in play 2.7. on scala 2.11
+                                  scalaVersions.filter(version => version.startsWith("2.12"))
+     }
+}

--- a/src/main/scala/reactivemongo/ReactiveMongoHelper.scala
+++ b/src/main/scala/reactivemongo/ReactiveMongoHelper.scala
@@ -18,11 +18,10 @@ package reactivemongo
 
 import reactivemongo.core.nodeset.Authenticate
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext}
 import reactivemongo.api._
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 object ReactiveMongoHelper {
 

--- a/src/main/scala/uk/gov/hmrc/mongo/SimpleMongoConnection.scala
+++ b/src/main/scala/uk/gov/hmrc/mongo/SimpleMongoConnection.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.mongo
 import reactivemongo.api.FailoverStrategy
 
 import scala.concurrent.duration.FiniteDuration
-import scala.language.postfixOps
 
 trait SimpleMongoConnection {
 


### PR DESCRIPTION
Bump reactivemongo to 0.20.2
Build for play 2.7 - Note, this is only for scala 2.12, since reactivemongo was build against an old version of akka, which is incompatible for scala 2.11.