### PR TITLE
BDOG-910: Use  key to lookup default heartbeatFrequencyMS

### DIFF
--- a/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
+++ b/src/main/scala/play/modules/reactivemongo/MongoConfig.scala
@@ -64,6 +64,7 @@ class MongoConfig(
 
   lazy val defaultHeartbeatFrequencyMS: Option[Int] =
     mongoConfig.getOptional[Int]("defaultHeartbeatFrequencyMS")
+      .orElse(configuration.getOptional[Int]("platform.mongodb.defaultHeartbeatFrequencyMS")) // see BDOG-910 comments
 
   private lazy val mongoConfig: Configuration = configuration
     .getOptional[Configuration]("mongodb")

--- a/src/test/scala/play/modules/reactivemongo/MongoConfigSpec.scala
+++ b/src/test/scala/play/modules/reactivemongo/MongoConfigSpec.scala
@@ -117,6 +117,18 @@ class MongoConfigSpec extends WordSpec with MockFactory with PropertyChecks {
         val value = mongoConfig(s"$mongodbConfigKey.defaultHeartbeatFrequencyMS" -> defaultHeartbeatFrequencyMS).defaultHeartbeatFrequencyMS
         value shouldBe Some(defaultHeartbeatFrequencyMS)
       }
+
+      s"ignore 'platform.mongodb.defaultHeartbeatFrequencyMS' if $mongodbConfigKey.defaultHeartbeatFrequencyMS specified" in new Setup {
+        val defaultValue = 999
+        val value = mongoConfig("platform.mongodb.defaultHeartbeatFrequencyMS" -> defaultValue, s"$mongodbConfigKey.defaultHeartbeatFrequencyMS" -> defaultHeartbeatFrequencyMS).defaultHeartbeatFrequencyMS
+        value shouldBe Some(defaultHeartbeatFrequencyMS)
+      }
+
+      s"fallback to 'platform.mongodb.defaultHeartbeatFrequencyMS' if $mongodbConfigKey.defaultHeartbeatFrequencyMS not specified" in new Setup {
+        val defaultValue = 999
+        val value = mongoConfig("platform.mongodb.defaultHeartbeatFrequencyMS" -> defaultValue, s"$mongodbConfigKey.uri" -> "something").defaultHeartbeatFrequencyMS
+        value shouldBe Some(defaultValue)
+      }
     }
   }
 


### PR DESCRIPTION
We had trouble rolling out a platform-wide default in app-config-common,
as the configuration currently has some applications using
'Prod.mongodb'. See comments on the JIRA ticket for further description.